### PR TITLE
Error Handling - Command execution on first run #6

### DIFF
--- a/src/wrestlingtournamentcli/Model.java
+++ b/src/wrestlingtournamentcli/Model.java
@@ -53,7 +53,6 @@ public class Model {
         this.wrestlerList = new ArrayList();
         this.bracketList = new ArrayList();
         this.matchBank = new ArrayList();
-        this.teamList.add(new Team("BYE", "", ""));
         initializeWeightClasses();
         matches = 0;
     }
@@ -394,17 +393,29 @@ public class Model {
 
     public static void printWrestlers() {
         Collections.sort(wrestlerList);
+        if (wrestlerList.size() == 0) {
+        	System.out.println("Error: There is no Wrestler exist");
+        }
+        else {
         System.out.println("List of Wrestlers: ");
         for (int i = 0; i != wrestlerList.size(); i++) {
             System.out.println(wrestlerList.get(i));
+        }
         }
     }
 
     public static void printTeams() {
         Collections.sort(teamList);
+        if (teamList.size() == 0) {
+        	System.out.println("Error: There is no team exist");
+        }
+        else {
+        	
+        
         System.out.println("List of Teams: ");
         for (int i = 0; i != teamList.size(); i++) {
             System.out.println(teamList.get(i));
+        }
         }
     }
 


### PR DESCRIPTION
Fix for issue: Error Handling - Command execution on first run #6

When 
`VIEW-TEAMS`
is run and there are no teams that exist, an error message appears instead of
List of Teams:
BYE () Points: 0
and
when
`VIEW-WRESTLERS`
is run, an error message appears is there are no wrestlers in the list instead of
“List of Wrestlers:” with no information following it.
